### PR TITLE
Add build script for .vsix file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+build

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,5 +1,3 @@
-// See https://go.microsoft.com/fwlink/?LinkId=733558
-// for the documentation about the tasks.json format
 {
 	"version": "2.0.0",
 	"tasks": [
@@ -15,6 +13,13 @@
 				"kind": "build",
 				"isDefault": true
 			}
+		},
+		{
+			"label": "build",
+			"type": "shell",
+			"command": "npm run build",
+			"group": "build",
+			"problemMatcher": []
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "format": "npx @biomejs/biome format --write src",
     "lint": "npx @biomejs/biome lint --write src",
     "check": "npx @biomejs/biome check --write src",
-    "test": "vscode-test"
+    "test": "vscode-test",
+    "build": "vsce package"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
Add a script to build the .vsix file.

* **.gitignore**
  * Add `build` directory to the ignore list.

* **package.json**
  * Add a new script named `build` to run `vsce package`.

* **.vscode/tasks.json**
  * Add a new task to run the `build` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JuanCamiloGrA/commitmaster-ai/pull/1?shareId=b2ad42a0-31a1-4b2d-aad2-de918abe96d4).